### PR TITLE
Task and page organization: distribute tasks across journal-style pages by date

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Logseq Todoist Backup
 
-Logseq plugin that keeps a read-only backup of all Todoist tasks inside a dedicated page of your graph.
+Logseq plugin that keeps a read-only backup of all Todoist tasks organized in journal-style pages within your graph.
 
 ## Overview
 
@@ -18,6 +18,7 @@ Logseq plugin that keeps a read-only backup of all Todoist tasks inside a dedica
 - Automatic background sync with a configurable interval (default 5 minutes).
 - Updates existing blocks based on `todoist-id::`, avoiding duplicates and removing tasks that no longer exist while preserving completed tasks.
 - Generates Logseq-friendly blocks including links, description, project, and labels prefixed with `#`.
+- Tasks are organized in date-based pages (`todoist/YYYY-MM-DD`) to maintain performance as your backup grows. Tasks without dates are stored in `todoist/Backlog`.
 
 ## Requirements
 
@@ -35,7 +36,7 @@ Logseq plugin that keeps a read-only backup of all Todoist tasks inside a dedica
 Inside the plugin settings provide:
 
 - `Todoist token`: personal token from [Todoist Integrations](https://todoist.com/prefs/integrations).
-- `Target page`: name of the Logseq page where tasks will be synced (defaults to `todoist`).
+- `Target page`: prefix for the Logseq pages where tasks will be synced (defaults to `todoist`). Tasks will be organized under `{prefix}/YYYY-MM-DD` and `{prefix}/Backlog`.
 - `Sync interval (min)`: minutes between automatic background syncs (defaults to `5`).
 
 ## Usage
@@ -57,7 +58,12 @@ Dates are normalized to `YYYY-MM-DD`. Labels are sanitized and prefixed with `#`
 ## Sync behavior
 
 - Each task is identified by `todoist-id::`. Existing blocks are updated, new ones appended, and obsolete ones removed. Completed tasks remain available unless deleted in Todoist.
-- When no tasks are returned, a placeholder block with `No tasks found.` is inserted.
+- Tasks are automatically distributed to pages based on their dates:
+  - **Completed tasks**: placed in `{prefix}/{completion_date}` (e.g., `todoist/2025-10-18`)
+  - **Active tasks with due dates**: placed in `{prefix}/{due_date}` (e.g., `todoist/2025-10-20`)
+  - **Tasks without dates**: placed in `{prefix}/Backlog`
+- When a task's date changes, it is automatically moved to the appropriate page during the next sync.
+- When no tasks are found for a page, a placeholder block with `No tasks found.` is inserted.
 - All interactions with Todoist are read-only.
 
 ## Development

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,4 @@ export const TODOIST_COMMENT_ID_PROPERTY = "todoist-comment-id";
 export const TODOIST_COMMENT_POSTED_PROPERTY = "todoist-comment-posted";
 export const PLACEHOLDER_CONTENT = "No tasks found.";
 export const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+export const BACKLOG_PAGE_SUFFIX = "Backlog";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import "@logseq/libs";
 
-import { buildBlocks, writeBlocks } from "./blocks";
+import { writeBlocks } from "./blocks";
 import {
   buildLabelMap,
   buildNameMap,
@@ -200,12 +200,11 @@ async function syncTodoist(trigger: "manual" | "auto") {
       ? await enrichTasksWithComments(filteredTasks, token)
       : filteredTasks;
 
-    const blocks = buildBlocks(tasksForBlocks, projectMap, labelMap);
-    await writeBlocks(pageName, blocks);
+    await writeBlocks(pageName, tasksForBlocks, projectMap, labelMap);
 
     if (trigger === "manual") {
       await logseq.UI.showMsg(
-        `Todoist backup synced (${blocks.length} tasks).`,
+        `Todoist backup synced (${tasksForBlocks.length} tasks).`,
         "success"
       );
     } else {


### PR DESCRIPTION
This update improves how Todoist tasks are organized within Logseq by implementing a journal-style page distribution. The primary logic ensures that:

- **Completed tasks** are placed in date-based pages using their `completed_date` or `completed_at` properties, resulting in organization under `{page_name}/YYYY-MM-DD`.
- **Active tasks with due dates** are sorted into `{page_name}/YYYY-MM-DD` corresponding to their `due` date.
- **Tasks without any dates** are placed in a backlog page: `{page_name}/Backlog`.

This prevents the main backup pages from becoming bloated and ensures Logseq maintains performance as task history grows. When a task's key date changes (for instance, when it is completed or its due date moves), it is automatically reallocated to the correct page on the next sync.

**Key implementation details:**
- Refactored organization logic into `blocks.ts` with dedicated functions:
  - `resolveTaskPageName`: determines the correct destination page for a given Todoist task based on its state and dates.
  - `writeBlocks`: responsible for grouping tasks by their target page and handling the distribution.
  - `cleanupObsoletePages`: ensures tasks are removed from their old pages if their categorization has changed, except for blocks preserving historical completion data.
- All code observes Logseq and plugin conventions, including validation, sanitization, and strict TypeScript typing.
- Modules boundaries reinforced: no blending of UI, API, or organization logic.
- AGENT.md and README.md updated to document the new behavior and clarify distribution rules for future maintainers and users.
- Lint and build steps succeed with no type errors.

**Why:**
- Keeps Logseq performant as the number of tasks grows.
- Allows historical browsing of completed tasks by date.
- Makes the backup structure clear and intuitive for end-users.
- Respects the need for non-destructive sync: completed (historical) tasks persist, only deleted items are removed.

**Testing and validation:**
- Manual sync and auto sync confirm tasks are moved/pages created as expected.
- Changes to task completion or due dates result in correct reallocation.
- Pages with no tasks get a placeholder block ("No tasks found.") to preserve page visibility.

This change builds a strong foundation for future enhancements (such as filtering by date or easy migration of Logseq journal entries based on completed tasks).

fixed: #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks are now automatically organized into journal-style pages by date.
  * Tasks are distributed based on completion date, due date, or to a Backlog page.
  * Automatic redistribution when dates change during sync.
  * Prevents performance bottlenecks from single-page accumulation.

* **Documentation**
  * Updated guides describing date-based page organization and sync behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->