### PR TITLE
feat(blocks): robust @label → #label converter preserves wiki-link and email context

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -38,7 +38,7 @@ TypeScript & Validation Expectations
 - Validate all external inputs aggressively:
   - Todoist responses: guard optional fields, normalize IDs to `string`, validate dates against `ISO_DATE_PATTERN`, and handle pagination cursors defensively.
   - Logseq settings: trim strings, coerce numbers, clamp intervals (`>= 1 minute`); reuse `readSettingsWithInterval` for timing.
-- User-provided text: sanitize using existing helpers (`safeText`, `safeLinkText`, `formatLabelTag`, `convertInlineTodoistLabels`) before embedding into Logseq blocks; `safeLinkText` preserves Logseq wiki links and Markdown bracketed labels while stripping unmatched brackets; `convertInlineTodoistLabels` transforms Todoist inline labels (`@label-name`) to Logseq hashtags (`#label-name`) while preserving email addresses.
+- User-provided text: sanitize using existing helpers (`safeText`, `safeLinkText`, `formatLabelTag`, `convertInlineTodoistLabels`) before embedding into Logseq blocks; `safeLinkText` preserves Logseq wiki links and Markdown bracketed labels while stripping unmatched brackets; `convertInlineTodoistLabels` transforms Todoist inline labels (`@label-name`) to Logseq hashtags (`#label-name`) while preserving email addresses and leaving `@` mentions inside `[[wiki links]]` untouched.
 - Prefer `unknown` over `any` for new external payloads; narrow via predicates or dedicated type guards.
 - Handle async errors with try/catch; present actionable messages via `logseq.UI.showMsg` and log details using `logError()` from `logger.ts`.
 


### PR DESCRIPTION
Fixes overzealous conversion of `@label` when transforming Todoist task text for Logseq, which previously led to false positives in mentions, emails (user@email.com), and especially inside wiki page links `[[Page @user]]` (commonly used by users for citations and proper names in Logseq).

Now, the `convertInlineTodoistLabels` function only applies conversion outside wiki links (`[[...]]`), leaving mentions inside links untouched and still preserving emails and other legitimate uses of `@`. This resolves real-world cases where migrated content would lose intended meaning or become cluttered with incorrect tags, maintaining backup fidelity and improving tag/search usability for original Todoist labels.

Includes validations to ensure:
- `@label` is converted to `#label` only outside `[[ ]]`
- Emails and other formats are not affected
- Legitimate `@` usage inside links is preserved

This change increases backup trustworthiness and eliminates semantic noise on daily journal and backlog pages generated by the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conversion of Todoist inline labels to properly preserve @ mentions within wiki links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->